### PR TITLE
Add minimal example for splitting environment and agent into two containers.

### DIFF
--- a/split_containers_example/Readme.md
+++ b/split_containers_example/Readme.md
@@ -1,0 +1,1 @@
+This is a suggestion how to split the environment and the agent in dedicated containers. See the corresponding [Github issue](https://github.com/rdnfn/beobench/issues/86) for details.

--- a/split_containers_example/docker-compose.yml
+++ b/split_containers_example/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+services:
+
+  beobench-rabitmq-broker:
+    container_name: beobench-rabitmq-broker
+    image: rabbitmq:3
+    init: true # Faster shutdown.
+
+  beobench-environment-dummy:
+    container_name: beobench-environment-dummy
+    build:
+      context: ./source
+      dockerfile: Dockerfile_environment
+    init: true # Faster shutdown.
+
+  beobench-agent-dummy:
+    container_name: beobench-agent-dummy
+    build:
+      context: ./source
+      dockerfile: Dockerfile_agent
+    init: true # Faster shutdown.

--- a/split_containers_example/source/Dockerfile_agent
+++ b/split_containers_example/source/Dockerfile_agent
@@ -1,0 +1,11 @@
+FROM python:3.10
+
+RUN pip install celery numpy
+
+RUN mkdir -p /source/
+WORKDIR /source/
+COPY __init__.py __init__.py
+COPY envwrapper.py envwrapper.py
+COPY agent.py agent.py
+
+ENTRYPOINT [ "python", "-u", "/source/agent.py" ]

--- a/split_containers_example/source/Dockerfile_environment
+++ b/split_containers_example/source/Dockerfile_environment
@@ -1,0 +1,11 @@
+FROM python:3.10
+
+RUN pip install celery numpy
+
+RUN mkdir -p /source/
+WORKDIR /source/
+COPY __init__.py __init__.py
+COPY envwrapper.py envwrapper.py
+COPY environment environment
+
+ENTRYPOINT [ "celery", "-A", "envwrapper", "worker", "--loglevel=INFO" ]

--- a/split_containers_example/source/__init__.py
+++ b/split_containers_example/source/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+"""
+"""

--- a/split_containers_example/source/agent.py
+++ b/split_containers_example/source/agent.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""
+A simple dummy agent that will do steps of 1.
+"""
+
+from time import sleep
+
+import numpy as np
+
+from envwrapper import step, reset
+
+async_result = reset.delay()
+observation = async_result.get()
+print(
+    "Agent received initial observation: {} of type {}".format(
+        observation, type(observation)
+    )
+)
+
+while True:
+    async_result = step.delay(np.ones(1))
+    observation = async_result.get()
+    print(
+        "Agent received observation: {} of type {}".format(
+            observation, type(observation)
+        )
+    )
+    sleep(1)

--- a/split_containers_example/source/environment/dummyenv.py
+++ b/split_containers_example/source/environment/dummyenv.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""
+Some placeholder for a propper gym environment.
+"""
+import numpy as np
+
+
+class DummyEnvironment:
+    """
+    Replace this with a proper gym environemt.
+    """
+
+    internal_state = None
+
+    def reset(self):
+        self.internal_state = np.zeros(1)
+        observation = self.internal_state
+        print("RESET. Obs is: {}".format(observation))
+        return observation
+
+    def step(self, action):
+        self.internal_state += action
+        observation = self.internal_state
+        print("STEP. Obs is: {}".format(observation))
+        return observation

--- a/split_containers_example/source/envwrapper.py
+++ b/split_containers_example/source/envwrapper.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+This does the celery connection magic.
+"""
+from celery import Celery
+
+# This is a conditional import, i.e. it will import the environment if it is
+# available (only in the environment container).
+try:
+    from environment.dummyenv import DummyEnvironment
+except ImportError:
+    DummyEnvironment = None
+
+if DummyEnvironment is not None:
+    env = DummyEnvironment()
+
+# Everything below is important for the agent script too.
+app = Celery(
+    "remote-environment",
+    broker="pyamqp://guest@beobench-rabitmq-broker//",
+    # This is important to let us wait for results, i.e. to  the
+    # interaction with the environment synchronous.
+    result_backend="rpc://",
+    result_persistent=False,
+)
+# Allows to send numpy arrays.
+app.conf.task_serializer = "pickle"
+app.conf.result_serializer = "pickle"
+app.conf.accept_content = ["application/json", "application/x-python-serialize"]
+
+
+# Define the existing methods that can be called remotly to interact
+@app.task
+def reset():
+    return env.reset()
+
+
+@app.task
+def step(action):
+    return env.step(action)


### PR DESCRIPTION
Works with identical python versions for now.

This could be a first approach to improve issue #86 